### PR TITLE
Repo now self-tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
 #         pytest --cov=./ --cov-report=xml
 
     - name: Upload coverage to Codecov  
-      uses: .
+      uses: ./
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         flags: unittest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,24 @@
+name: Example workflow for Codecov
+on: [push]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+   
+#     - name: Setup Python  
+#       uses: actions/setup-python@master
+
+#     - name: Generate coverage report
+#       run: |
+#         pip install pytest
+#         pip install pytest-cov
+#         pytest --cov=./ --cov-report=xml
+
+    - name: Upload coverage to Codecov  
+      uses: .action
+      with:
+        token: ${{secrets.CODECOV_TOKEN}}
+        flags: unittest
+        name: codecov-1
+        #badstuff: morebadstuff

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
 #         pytest --cov=./ --cov-report=xml
 
     - name: Upload coverage to Codecov  
-      uses: .action
+      uses: ./action
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         flags: unittest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
 #         pytest --cov=./ --cov-report=xml
 
     - name: Upload coverage to Codecov  
-      uses: ./action
+      uses: .
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         flags: unittest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Codecov @codecov
 
-FROM alpine:3.10
+FROM ubuntu:latest
 
 WORKDIR /app
 COPY . /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM ubuntu:latest
 WORKDIR /app
 COPY . /app
 
-RUN apk add --no-cache curl bash git
+# RUN apk add --no-cache curl bash git
 
 RUN chmod +x /app/entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM ubuntu:latest
 WORKDIR /app
 COPY . /app
 
-# RUN apk add --no-cache curl bash git
+RUN sudo apt update && sudo apt install -y curl
 
 RUN chmod +x /app/entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM ubuntu:latest
 WORKDIR /app
 COPY . /app
 
-RUN sudo apt update && sudo apt install -y curl
+RUN apt update && apt install -y curl
 
 RUN chmod +x /app/entrypoint.sh
 


### PR DESCRIPTION
Add workflow to repo that tests action locally

Switch to Ubuntu for base since alpine uses BusyBox and and `find` does not have the flags we need for the GCov file search.