### PR TITLE
Enhancement: Use alpine instead of ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 # Codecov @codecov
 
-FROM ubuntu:latest
+FROM alpine:3.10
 
 WORKDIR /app
 COPY . /app
 
-RUN apt update && apt install -y curl git mercurial
+RUN apk add --no-cache \
+    curl \
+    git \
+    mercurial
 
 RUN chmod +x /app/entrypoint.sh
 


### PR DESCRIPTION
This PR

* [x] uses `alpine` instead of `ubuntu`

💁‍♂ Since GitHub actions builds the image every time (unless we specify a pre-built and tagged image, for example, on Docker Hub or in the GitHub package registry), using this action currently takes a ridiculously long time (much, much longer than just downloading the script and executing it). Using `alpine` instead of `ubuntu` might just cut down that precious build time.

Also see 

* https://github.com/localheinz/php-library-template/pull/98
* https://github.com/localheinz/php-library-template/pull/98/checks#step:2:1
* https://github.com/codecov/codecov-action/issues/15

/cc @spawnia

![Screen Shot 2019-09-11 at 22 54 16](https://user-images.githubusercontent.com/605483/64734593-35673180-d4e7-11e9-8e72-aa66546c7333.png)