### PR TITLE
Allow for passing names with spaces

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,28 +10,28 @@ then
   exit 1
 elif [ "x$INPUT_TOKEN" != "x" ] && [ "x$INPUT_FILE" != "x" ] && [ "x$INPUT_FLAGS" != "x" ] && [ "x$INPUT_NAME" != "x" ]
 then
-  curl -s https://codecov.io/bash | bash -s -- -t $INPUT_TOKEN -f $INPUT_FILE -F $INPUT_FLAGS -n $INPUT_NAME
+  curl -s https://codecov.io/bash | bash -s -- -t "$INPUT_TOKEN" -f "$INPUT_FILE" -F "$INPUT_FLAGS" -n "$INPUT_NAME"
 elif [ "x$INPUT_TOKEN" != "x" ] && [ "x$INPUT_FILE" != "x" ] && [ "x$INPUT_FLAGS" != "x" ]
 then
-  curl -s https://codecov.io/bash | bash -s -- -t $INPUT_TOKEN -f $INPUT_FILE -F $INPUT_FLAGS
+  curl -s https://codecov.io/bash | bash -s -- -t "$INPUT_TOKEN" -f "$INPUT_FILE" -F "$INPUT_FLAGS"
 elif [ "x$INPUT_TOKEN" != "x" ] && [ "x$INPUT_FILE" != "x" ] && [ "x$INPUT_NAME" != "x" ]
 then
-  curl -s https://codecov.io/bash | bash -s -- -t $INPUT_TOKEN -f $INPUT_FILE -n $INPUT_NAME
+  curl -s https://codecov.io/bash | bash -s -- -t "$INPUT_TOKEN" -f "$INPUT_FILE" -n "$INPUT_NAME"
 elif [ "x$INPUT_TOKEN" != "x" ] && [ "x$INPUT_NAME" != "x" ] && [ "x$INPUT_FLAGS" != "x" ]
 then
-  curl -s https://codecov.io/bash | bash -s -- -t $INPUT_TOKEN -n $INPUT_NAME -F $INPUT_FLAGS
+  curl -s https://codecov.io/bash | bash -s -- -t "$INPUT_TOKEN" -n "$INPUT_NAME" -F "$INPUT_FLAGS"
 elif [ "x$INPUT_TOKEN" != "x" ] && [ "x$INPUT_FILE" != "x" ]
 then
-  curl -s https://codecov.io/bash | bash -s -- -t $INPUT_TOKEN -f $INPUT_FILE
+  curl -s https://codecov.io/bash | bash -s -- -t "$INPUT_TOKEN" -f "$INPUT_FILE"
 elif [ "x$INPUT_TOKEN" != "x" ] && [ "x$INPUT_FLAGS" != "x" ]
 then
-  curl -s https://codecov.io/bash | bash -s -- -t $INPUT_TOKEN -F $INPUT_FLAGS
+  curl -s https://codecov.io/bash | bash -s -- -t "$INPUT_TOKEN" -F "$INPUT_FLAGS"
 elif [ "x$INPUT_TOKEN" != "x" ] && [ "x$INPUT_NAME" != "x" ]
 then
-  curl -s https://codecov.io/bash | bash -s -- -t $INPUT_TOKEN -n $INPUT_NAME
+  curl -s https://codecov.io/bash | bash -s -- -t "$INPUT_TOKEN" -n "$INPUT_NAME"
 elif [ "x$INPUT_TOKEN" != "x" ]
 then
-  curl -s https://codecov.io/bash | bash -s -- -t $INPUT_TOKEN
+  curl -s https://codecov.io/bash | bash -s -- -t "$INPUT_TOKEN"
 else
   echo "Please provide an upload token from codecov.io with valid arguments"
   exit 1


### PR DESCRIPTION
The bash uploader allows for names with spaces, but any spaces passed to this action currently will not be passed on.

For example, if `$INPUT_NAME` is set to "Hello World", the resulting script call will be:
```bash
curl -s https://codecov.io/bash | bash -s -- -t $INPUT_TOKEN -n Hello World
```
Which then results in the uploaded name "Hello"

This PR adds quotes around all passed arguments to allow for multi-word strings. Now passing "Hello World" will yield
```bash
curl -s https://codecov.io/bash | bash -s -- -t "$INPUT_TOKEN" -n "Hello World"
```
Which will correctly set the name.