### PR TITLE
Fix shell command issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
 # Codecov @codecov
 
-FROM ubuntu:latest
+FROM debian:stretch-slim
 
-WORKDIR /app
-COPY . /app
+RUN apt-get update && apt-get install -y \
+		ca-certificates \
+		curl \
+		git \
+		mercurial \
+	--no-install-recommends && rm -r /var/lib/apt/lists/*
 
-RUN apt update && apt install -y curl git mercurial
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
-RUN chmod +x /app/entrypoint.sh
-
-ENTRYPOINT [ "/app/entrypoint.sh" ]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,38 +1,20 @@
-#!/bin/bash
+#!/bin/sh
 
 # Codecov @codecov
 
 set -eu
 
-if [ $# -eq 0 ]
-then
-  echo "Please provide an upload token from codecov.io"
-  exit 1
-elif [ "x$INPUT_TOKEN" != "x" ] && [ "x$INPUT_FILE" != "x" ] && [ "x$INPUT_FLAGS" != "x" ] && [ "x$INPUT_NAME" != "x" ]
-then
-  curl -s https://codecov.io/bash | bash -s -- -t $INPUT_TOKEN -f $INPUT_FILE -F $INPUT_FLAGS -n $INPUT_NAME
-elif [ "x$INPUT_TOKEN" != "x" ] && [ "x$INPUT_FILE" != "x" ] && [ "x$INPUT_FLAGS" != "x" ]
-then
-  curl -s https://codecov.io/bash | bash -s -- -t $INPUT_TOKEN -f $INPUT_FILE -F $INPUT_FLAGS
-elif [ "x$INPUT_TOKEN" != "x" ] && [ "x$INPUT_FILE" != "x" ] && [ "x$INPUT_NAME" != "x" ]
-then
-  curl -s https://codecov.io/bash | bash -s -- -t $INPUT_TOKEN -f $INPUT_FILE -n $INPUT_NAME
-elif [ "x$INPUT_TOKEN" != "x" ] && [ "x$INPUT_NAME" != "x" ] && [ "x$INPUT_FLAGS" != "x" ]
-then
-  curl -s https://codecov.io/bash | bash -s -- -t $INPUT_TOKEN -n $INPUT_NAME -F $INPUT_FLAGS
-elif [ "x$INPUT_TOKEN" != "x" ] && [ "x$INPUT_FILE" != "x" ]
-then
-  curl -s https://codecov.io/bash | bash -s -- -t $INPUT_TOKEN -f $INPUT_FILE
-elif [ "x$INPUT_TOKEN" != "x" ] && [ "x$INPUT_FLAGS" != "x" ]
-then
-  curl -s https://codecov.io/bash | bash -s -- -t $INPUT_TOKEN -F $INPUT_FLAGS
-elif [ "x$INPUT_TOKEN" != "x" ] && [ "x$INPUT_NAME" != "x" ]
-then
-  curl -s https://codecov.io/bash | bash -s -- -t $INPUT_TOKEN -n $INPUT_NAME
-elif [ "x$INPUT_TOKEN" != "x" ]
-then
-  curl -s https://codecov.io/bash | bash -s -- -t $INPUT_TOKEN
+if [ "x$INPUT_FILE" != 'x' ]; then
+	curl -s https://codecov.io/bash | bash -s -- \
+		-f "$INPUT_FILE" \
+		-t "$INPUT_TOKEN" \
+		-n "$INPUT_NAME" \
+		-F "$INPUT_FLAGS" \
+		-Z || echo 'Codecov upload failed'
 else
-  echo "Please provide an upload token from codecov.io with valid arguments"
-  exit 1
+	curl -s https://codecov.io/bash | bash -s -- \
+		-t "$INPUT_TOKEN" \
+		-n "$INPUT_NAME" \
+		-F "$INPUT_FLAGS" \
+		-Z || echo 'Codecov upload failed'
 fi


### PR DESCRIPTION
Similar to https://github.com/codecov/codecov-circleci-orb/pull/17

1. `codecov-bash` already handles optional arguments passed to it, so let's not duplicate that work here.
2. Do not exit with a non-zero exit status when upload fails, or even if the token is not set (i.e. in forks / pull requests). This matches the behaviour of the CircleCI orb.
3. Use `debian:stretch-slim` instead of `ubuntu:latest` as base for the Docker image, since it's smaller and forces us to be a more explicit in our dependencies.
4. `COPY` only what we need, and no need to set `WORKDIR`.