### PR TITLE
Add directory and file save

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ Codecov's Action currently supports five inputs from the user: `token`, `file`, 
 | :---:     |     :---:   |    :---:   |
 | `token`  | Used to authorize coverage report uploads  | *Required for private repos* |
 | `file`  | Path to the coverage report(s) | Optional
+| `directory` | Directory to search for coverage reports. | Optional
 | `flags`  | Flag the upload to group coverage metrics (unittests, uitests, etc.). Multiple flags are separated by a comma (ui,chrome) | Optional
 | `env_vars`  | Environment variables to tag the upload with. Multiple env variables can be separated with commas (e.g. `OS,PYTHON`) | Optional
 | `name`  | Custom defined name for the upload | Optional
 | `fail_ci_if_error`  | Specify if CI pipeline should fail when Codecov runs into errors during upload. *Defaults to **false*** | Optional
+| `path_to_write_report` | Write upload file to path before uploading | Optional
 
 ### Example `workflow.yml` with Codecov Action
 
@@ -71,10 +73,12 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
+        directory: ./coverage/reports/
         flags: unittests
         env_vars: OS,PYTHON
         name: codecov-umbrella
         fail_ci_if_error: true
+        path_to_write_report: ./coverage/codecov_report.gz
 ```
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -11,8 +11,14 @@ inputs:
   file:
     description: 'Path to coverage file to upload'
     required: false
+  directory:
+    description: 'Directory to search for coverage reports.'
+    required: false
   flags:
     description: 'Flag upload to group coverage metrics (e.g. unittests | integration | ui,chrome)'
+    required: false
+  path_to_write_report:
+    description: 'Write upload file to path before uploading'
     required: false
   env_vars:
     description: 'Environment variables to tag the upload with (e.g. PYTHON | OS,PYTHON)'

--- a/dist/index.js
+++ b/dist/index.js
@@ -2214,6 +2214,8 @@ try {
   const flags = core.getInput("flags");
   const file = core.getInput("file");
   const env_vars = core.getInput("env_vars");
+  const dir = core.getInput("directory");
+  const write_path = core.getInput("path_to_write_report");
 
   fail_ci = core.getInput("fail_ci_if_error").toLowerCase();
 
@@ -2287,6 +2289,12 @@ try {
         );
       }
 
+      if (dir) {
+        execArgs.push(
+          "-s", `${dir}`
+        );
+      }
+
       execArgs.push(
         "-n", `${name}`,
         "-F", `${flags}`
@@ -2301,6 +2309,12 @@ try {
       if (env_vars_arg.length) {
         execArgs.push(
           "-e", env_vars_arg.join(",")
+        );
+      }
+
+      if (write_path) {
+        execArgs.push(
+          "-q", `${write_path}`
         );
       }
 

--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ try {
   const flags = core.getInput("flags");
   const file = core.getInput("file");
   const env_vars = core.getInput("env_vars");
+  const dir = core.getInput("directory");
+  const write_path = core.getInput("path_to_write_report");
 
   fail_ci = core.getInput("fail_ci_if_error").toLowerCase();
 
@@ -83,6 +85,12 @@ try {
         );
       }
 
+      if (dir) {
+        execArgs.push(
+          "-s", `${dir}`
+        );
+      }
+
       execArgs.push(
         "-n", `${name}`,
         "-F", `${flags}`
@@ -97,6 +105,12 @@ try {
       if (env_vars_arg.length) {
         execArgs.push(
           "-e", env_vars_arg.join(",")
+        );
+      }
+
+      if (write_path) {
+        execArgs.push(
+          "-q", `${write_path}`
         );
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov-action",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Upload coverage reports to Codecov from GitHub Actions",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Adding some functionality from the bash script and exposing it here. In particular
- specifying a directory to search for coverage reports
- specify a path to save down the coverage report sent to Codecov before uploading