### PR TITLE
Add "working-directory:" input

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ steps:
 
 Codecov's Action currently supports five inputs from the user: `token`, `file`, `flags`,`name`, and `fail_ci_if_error`. These inputs, along with their descriptions and usage contexts, are listed in the table below:
 
->**Update**: We've removed the `yml` parameter with the latest release of this action. Please put your custom codecov yaml file at the root of the repo because other locations will no longer be supported in the future.
-
 | Input  | Description | Usage |
 | :---:     |     :---:   |    :---:   |
 | `token`  | Used to authorize coverage report uploads  | *Required for private repos* |
@@ -47,6 +45,7 @@ Codecov's Action currently supports five inputs from the user: `token`, `file`, 
 | `fail_ci_if_error`  | Specify if CI pipeline should fail when Codecov runs into errors during upload. *Defaults to **false*** | Optional
 | `path_to_write_report` | Write upload file to path before uploading | Optional
 | `verbose` | Specify whether the Codecov output should be verbose | Optional
+| `working-directory` | Directory in which to execute `codecov.sh` | Optional
 | `xcode_derived_data` | Custom Derived Data Path for Coverage.profdata and gcov processing | Optional
 | `xcode_package` | Specify packages to build coverage. Uploader will only build these packages. This can significantly reduces time to build coverage reports. -J 'MyAppName' Will match "MyAppName" and "MyAppNameTests" -J '^ExampleApp$' Will match only "ExampleApp" not "ExampleAppTests" | Optional
 

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
   verbose:
     description: 'Specify whether the Codecov output should be verbose'
     required: false
+  working-directory:
+    description: 'Directory in which to execute codecov.sh'
+    required: false
 branding:
   color: 'red'
   icon: 'umbrella'

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ try {
   const dir = core.getInput("directory");
   const write_path = core.getInput("path_to_write_report");
   const verbose = core.getInput("verbose");
+  const working_dir = core.getInput("working-directory");
   const xcode_derived_data = core.getInput("xcode_derived_data");
   const xcode_package = core.getInput("xcode_package");
 
@@ -135,6 +136,10 @@ try {
           execArgs.push(
             "-v"
           );
+        }
+
+        if (working_dir) {
+          options.cwd = working_dir;
         }
 
         if (xcode_derived_data) {


### PR DESCRIPTION
This PR adds an input `working-directory:`, the same name as GitHub Actions uses for generic (`run:`) steps: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsrun

The value is passed to the `cwd` option of GitHub's @actions/exec exec() method:
https://github.com/actions/toolkit/blob/d9347d4ab99fd507c0b9104b2cf79fb44fcc827d/packages/exec/src/interfaces.ts#L5-L7

This allows the user to specify in which directory codecov.sh should run.

Other information:
- I have looked at #70 and https://github.com/codecov/codecov-action/issues/51#issuecomment-595077546 —this PR differs because it is not trying to address the deprecated/removed `-y` option to `codecov.sh`, but rather allow configuration of the directory in which the program is executed.
- The current instruction (e.g. in #51) to "place codecov.yml at the root of the repository" only covers a subset of possible workflows. This is because [GitHub's provided Checkout action has a `path:` option](https://github.com/marketplace/actions/checkout) that controls where each repository is checked out. $GITHUB_WORKSPACE (where this action currently always executes) will be a different directory from "the root of the repository" any time `path:` is used; this is common when a workflow checks out two or more repositories. This PR removes this restriction.
- I am not a JS developer. There are two things I suspect may need extra work, and I'd appreciate pointers on how to address them, or please push to this branch.
  - Aside from the top-level index.js that I've modified, dist/index.js appears to have the same content embedded. There are no instructions or hints on how to generate this file.
  - The path where codecov.sh is written may need to be inside the working directory, if any: https://github.com/codecov/codecov-action/blob/master/index.js#L42