### PR TITLE
Add timeout for loading Codecov bash script

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,8 @@ try {
 
   request({
     url: "https://codecov.io/bash",
-    json: false
+    json: false,
+    timeout: 30000,
   }, (error, response, body) => {
     try {
       if (error && fail_ci) {


### PR DESCRIPTION
When the Codecov server are down or do not respond, this action takes a long time to stop (last time I whitnessed was 12 minutes). This is slows down productivity and - since GitHub actions are billed by minute - adds additional costs.

This PR sets a timeout of 30 seconds for the HTTP request to download the script.