### PR TITLE
Implement Passthrough of Bash Uploader Arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ steps:
     name: codecov-umbrella # optional
     fail_ci_if_error: true # optional (default = false)
     verbose: true # optional (default = false)
+    bash_args: |
+      -P 123
+      -J "TestApp"
 ```
 >**Note**: This assumes that you've set your Codecov token inside *Settings > Secrets* as `CODECOV_TOKEN`. If not, you can [get an upload token](https://docs.codecov.io/docs/frequently-asked-questions#section-where-is-the-repository-upload-token-found-) for your specific repo on [codecov.io](https://www.codecov.io). Keep in mind that secrets are *not* available to forks of repositories.
 
@@ -47,6 +50,7 @@ Codecov's Action currently supports a number of inputs, along with their descrip
 | `fail_ci_if_error`  | Specify if CI pipeline should fail when Codecov runs into errors during upload. *Defaults to **false*** | Optional
 | `path_to_write_report` | Write upload file to path before uploading | Optional
 | `verbose` | Specify whether the Codecov output should be verbose | Optional
+| `bash_args` | Extra arguments to pass into the codecov bash script.  [List of possible arguments](https://docs.codecov.io/docs/about-the-codecov-bash-uploader#arguments). To add multiple arguments, refer to the example workflows.  | Optional
 
 ### Example `workflow.yml` with Codecov Action
 
@@ -86,6 +90,9 @@ jobs:
         fail_ci_if_error: true
         path_to_write_report: ./coverage/codecov_report.gz
         verbose: true
+        bash_args: |
+          -J 'TestApp'
+          -P 123
 ```
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ steps:
 
 ## Arguments
 
-Codecov's Action currently supports five inputs from the user: `token`, `file`, `flags`,`name`, and `fail_ci_if_error`. These inputs, along with their descriptions and usage contexts, are listed in the table below:
+Codecov's Action currently supports a number of inputs, along with their descriptions and usage contexts, listed in the table below:
 
 >**Update**: We've removed the `yml` parameter with the latest release of this action. Please put your custom codecov yaml file at the root of the repo because other locations will no longer be supported in the future.
 

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,9 @@ inputs:
   verbose:
     description: 'Specify whether the Codecov output should be verbose'
     required: false
+  bash_args:
+    description: 'Extra arguments to pass into the codecov bash script.  One argument per line.'
+    required: false
 branding:
   color: 'red'
   icon: 'umbrella'

--- a/dist/index.js
+++ b/dist/index.js
@@ -2612,20 +2612,17 @@ try {
           );
         }
 
-        if (bash_args_clean.length) {
-          for(const x of bash_args_clean) {
-            const arg = x.slice(0,2);
-            const val = x.slice(2).trim();
-            execArgs.push(
-              `${arg}`, `${val}`
-            );
-          }
+        if (name) {
+          execArgs.push(
+            "-n", `${name}`
+          );
         }
 
-        execArgs.push(
-          "-n", `${name}`,
-          "-F", `${flags}`
-        );
+        if (flags) {
+          execArgs.push(
+            "-F", `${flags}`
+          );
+        }
 
         if (fail_ci) {
           execArgs.push(
@@ -2649,6 +2646,16 @@ try {
           execArgs.push(
             "-v"
           );
+        }
+
+        if (bash_args_clean.length) {
+          for(const x of bash_args_clean) {
+            const arg = x.slice(0,2);
+            const val = x.slice(2).trim();
+            execArgs.push(
+              `${arg}`, `${val}`
+            );
+          }
         }
 
         exec.exec("bash", execArgs, options)

--- a/dist/index.js
+++ b/dist/index.js
@@ -2535,9 +2535,7 @@ try {
   fail_ci = truthy.includes(core.getInput("fail_ci_if_error").toLowerCase());
 
   const bash_args = core.getInput("bash_args");
-  core.debug(`bash_args: ${bash_args}`);
   const bash_args_clean = bash_args.split(/[\n]+/).map(s => s.trim()).filter(i => i !== '');
-  core.debug(`bash_args_clean (${bash_args_clean.length}: ${bash_args_clean}`);
 
   request({
     json: false,
@@ -2614,6 +2612,16 @@ try {
           );
         }
 
+        if (bash_args_clean.length) {
+          for(const x of bash_args_clean) {
+            const arg = x.slice(0,2);
+            const val = x.slice(2).trim();
+            execArgs.push(
+              `${arg}`, `${val}`
+            );
+          }
+        }
+
         execArgs.push(
           "-n", `${name}`,
           "-F", `${flags}`
@@ -2641,16 +2649,6 @@ try {
           execArgs.push(
             "-v"
           );
-        }
-
-        if (bash_args_clean.length) {
-          for(const x of bash_args_clean) {
-            const arg = x.slice(0,2);
-            const val = x.slice(2).trim();
-            execArgs.push(
-              `${arg}`, `${val}`
-            );
-          }
         }
 
         exec.exec("bash", execArgs, options)

--- a/dist/index.js
+++ b/dist/index.js
@@ -2531,19 +2531,13 @@ try {
   const write_path = core.getInput("path_to_write_report");
   const verbose = core.getInput("verbose");
 
-  fail_ci = core.getInput("fail_ci_if_error").toLowerCase();
+  const truthy = ["yes","y","true","t","1"];
+  fail_ci = truthy.includes(core.getInput("fail_ci_if_error").toLowerCase());
 
-  if (
-    fail_ci === "yes" ||
-    fail_ci === "y" ||
-    fail_ci === "true" ||
-    fail_ci === "t" ||
-    fail_ci === "1"
-  ) {
-    fail_ci = true;
-  } else {
-    fail_ci = false;
-  }
+  const bash_args = core.getInput("bash_args");
+  core.debug(`bash_args: ${bash_args}`);
+  const bash_args_clean = bash_args.split(/[\n]+/).map(s => s.trim()).filter(i => i !== '');
+  core.debug(`bash_args_clean (${bash_args_clean.length}: ${bash_args_clean}`);
 
   request({
     json: false,
@@ -2647,6 +2641,16 @@ try {
           execArgs.push(
             "-v"
           );
+        }
+
+        if (bash_args_clean.length) {
+          for(const x of bash_args_clean) {
+            const arg = x.slice(0,2);
+            const val = x.slice(2).trim();
+            execArgs.push(
+              `${arg}`, `${val}`
+            );
+          }
         }
 
         exec.exec("bash", execArgs, options)

--- a/index.js
+++ b/index.js
@@ -96,20 +96,17 @@ try {
           );
         }
 
-        if (bash_args_clean.length) {
-          for(const x of bash_args_clean) {
-            const arg = x.slice(0,2);
-            const val = x.slice(2).trim();
-            execArgs.push(
-              `${arg}`, `${val}`
-            );
-          }
+        if (name) {
+          execArgs.push(
+            "-n", `${name}`
+          );
         }
 
-        execArgs.push(
-          "-n", `${name}`,
-          "-F", `${flags}`
-        );
+        if (flags) {
+          execArgs.push(
+            "-F", `${flags}`
+          );
+        }
 
         if (fail_ci) {
           execArgs.push(
@@ -133,6 +130,16 @@ try {
           execArgs.push(
             "-v"
           );
+        }
+
+        if (bash_args_clean.length) {
+          for(const x of bash_args_clean) {
+            const arg = x.slice(0,2);
+            const val = x.slice(2).trim();
+            execArgs.push(
+              `${arg}`, `${val}`
+            );
+          }
         }
 
         exec.exec("bash", execArgs, options)

--- a/index.js
+++ b/index.js
@@ -96,6 +96,16 @@ try {
           );
         }
 
+        if (bash_args_clean.length) {
+          for(const x of bash_args_clean) {
+            const arg = x.slice(0,2);
+            const val = x.slice(2).trim();
+            execArgs.push(
+              `${arg}`, `${val}`
+            );
+          }
+        }
+
         execArgs.push(
           "-n", `${name}`,
           "-F", `${flags}`
@@ -123,16 +133,6 @@ try {
           execArgs.push(
             "-v"
           );
-        }
-
-        if (bash_args_clean.length) {
-          for(const x of bash_args_clean) {
-            const arg = x.slice(0,2);
-            const val = x.slice(2).trim();
-            execArgs.push(
-              `${arg}`, `${val}`
-            );
-          }
         }
 
         exec.exec("bash", execArgs, options)

--- a/index.js
+++ b/index.js
@@ -15,19 +15,11 @@ try {
   const write_path = core.getInput("path_to_write_report");
   const verbose = core.getInput("verbose");
 
-  fail_ci = core.getInput("fail_ci_if_error").toLowerCase();
+  const truthy = ["yes","y","true","t","1"];
+  fail_ci = truthy.includes(core.getInput("fail_ci_if_error").toLowerCase());
 
-  if (
-    fail_ci === "yes" ||
-    fail_ci === "y" ||
-    fail_ci === "true" ||
-    fail_ci === "t" ||
-    fail_ci === "1"
-  ) {
-    fail_ci = true;
-  } else {
-    fail_ci = false;
-  }
+  const bash_args = core.getInput("bash_args");
+  const bash_args_clean = bash_args.split(/[\n]+/).map(s => s.trim()).filter(i => i !== '');
 
   request({
     json: false,
@@ -131,6 +123,16 @@ try {
           execArgs.push(
             "-v"
           );
+        }
+
+        if (bash_args_clean.length) {
+          for(const x of bash_args_clean) {
+            const arg = x.slice(0,2);
+            const val = x.slice(2).trim();
+            execArgs.push(
+              `${arg}`, `${val}`
+            );
+          }
         }
 
         exec.exec("bash", execArgs, options)


### PR DESCRIPTION
This should allow users to use arguments that can be used in the bash uploader.  
Should resolve #73, resolve #76, resolve #92.  May resolve #155 by yours truly by usage of `-P` argument

This also slightly optimized the truthy check in `fail_ci`.

Checks if `name` and `flags` inputs are used first before adding it into the bash arguments.  This eliminates the empty -n and -F flags.  Unsure if they were there on purpose though.

As well as minor rewording in the README in the Arguments section.

Couple of things to note:
- Bash args are one per line.  Pipe should be used if more than one bash arg needed.
- Based on your current args, I have it set to extract the first two characters for the arg, and the rest as the value of the arg.
- This doesn't check if the arg itself is valid.  It simply passes it through to the bash script.