### PR TITLE
Overwrite pull_request_target pr number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.2
+- # Overwrites pr number for pull_request_target events
+
 ## 1.3.1
 
 ### Fixes

--- a/dist/index.js
+++ b/dist/index.js
@@ -59636,6 +59636,9 @@ var buildExec = function () {
     if (overridePr) {
         execArgs.push('-P', "" + overridePr);
     }
+    else if ("" + context.eventName == 'pull_request_target') {
+        execArgs.push('-P', "" + context.payload.number);
+    }
     if (overrideTag) {
         execArgs.push('-T', "" + overrideTag);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov-action",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov-action",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Upload coverage reports to Codecov from GitHub Actions",
   "main": "index.js",
   "scripts": {

--- a/src/buildExec.ts
+++ b/src/buildExec.ts
@@ -143,6 +143,10 @@ const buildExec = () => {
   }
   if (overridePr) {
     execArgs.push('-P', `${overridePr}`);
+  } else if (
+    `${context.eventName}` == 'pull_request_target'
+  ) {
+    execArgs.push('-P', `${context.payload.number}`);
   }
   if (overrideTag) {
     execArgs.push('-T', `${overrideTag}`);


### PR DESCRIPTION
Fixes https://github.com/codecov/codecov-action/issues/155

This PR addresses the issue with `pull_request_target` events and Codecov pulling the wrong PR number. The Action will now force the value to the bash uploader.