### PR TITLE
Update bash uploader to 1.0.3

### DIFF
--- a/dist/codecov
+++ b/dist/codecov
@@ -5,7 +5,7 @@
 
 set -e +o pipefail
 
-VERSION="1.0.2"
+VERSION="1.0.3"
 
 codecov_flags=( )
 url="https://codecov.io"
@@ -1866,10 +1866,9 @@ else
         -H 'Accept: text/plain' \
         $curlargs \
         "$url/upload/v2?$query&attempt=$i" || echo 'HTTP 500')
-  # HTTP 200
-  # http://....
-  status=$(echo "$res" | head -1 | cut -d' ' -f2)
-  if [ "$status" = "" ] || [ "$status" = "200" ];
+  # {"message": "Coverage reports upload successfully", "uploaded": true, "queued": true, "id": "...", "url": "https://codecov.io/..."\}
+  uploaded=$(grep -o '\"uploaded\": [a-z]*' <<< "$res" | head -1 | cut -d' ' -f2)
+  if [ "$uploaded" = "true" ]
   then
     say "    Reports have been successfully queued for processing at ${b}$(echo "$res" | head -2 | tail -1)${x}"
     exit 0

--- a/src/codecov
+++ b/src/codecov
@@ -5,7 +5,7 @@
 
 set -e +o pipefail
 
-VERSION="1.0.2"
+VERSION="1.0.3"
 
 codecov_flags=( )
 url="https://codecov.io"
@@ -1866,10 +1866,9 @@ else
         -H 'Accept: text/plain' \
         $curlargs \
         "$url/upload/v2?$query&attempt=$i" || echo 'HTTP 500')
-  # HTTP 200
-  # http://....
-  status=$(echo "$res" | head -1 | cut -d' ' -f2)
-  if [ "$status" = "" ] || [ "$status" = "200" ];
+  # {"message": "Coverage reports upload successfully", "uploaded": true, "queued": true, "id": "...", "url": "https://codecov.io/..."\}
+  uploaded=$(grep -o '\"uploaded\": [a-z]*' <<< "$res" | head -1 | cut -d' ' -f2)
+  if [ "$uploaded" = "true" ]
   then
     say "    Reports have been successfully queued for processing at ${b}$(echo "$res" | head -2 | tail -1)${x}"
     exit 0


### PR DESCRIPTION
The current bash uploader is outdated and seems to be the cause of the issues reported in #330. Although I'm by no means certain, I haven't looked into this particularly deeply.

This PR updates the bash uploader to 1.0.3, which is the current version one can fetch from https://codecov.io/bash

Since the script is inlined in this repository, it's probably prudent to put a check in to verify that it's up-to-date, and fail CI if it's not. Is that something you'd want in a PR?