### PR TITLE
fix: Import version properly as string not object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.2
+### Fixes
+- # fix: Import version properly as string not object
+
 ## 1.5.1
 ### Fixes
 - #320 doc: add github actions badge

--- a/dist/index.js
+++ b/dist/index.js
@@ -1109,7 +1109,7 @@ function onceStrict (fn) {
 "use strict";
 
 exports.__esModule = true;
-var VERSION = 'v1.5.0';
+var VERSION = 'v1.5.2';
 exports["default"] = VERSION;
 
 
@@ -7188,7 +7188,7 @@ exports.checkBypass = checkBypass;
 exports.__esModule = true;
 var core = __webpack_require__(470);
 var github = __webpack_require__(469);
-var VERSION = __webpack_require__(52);
+var version_1 = __webpack_require__(52);
 var context = github.context;
 var isTrue = function (variable) {
     var lowercase = variable.toLowerCase();
@@ -7233,7 +7233,7 @@ var buildExec = function () {
     var filepath = workingDir ?
         workingDir + '/codecov.sh' : 'codecov.sh';
     var execArgs = [filepath];
-    execArgs.push('-n', "" + name, '-F', "" + flags, '-Q', "github-action-" + VERSION);
+    execArgs.push('-n', "" + name, '-F', "" + flags, '-Q', "github-action-" + version_1["default"]);
     var options = {};
     options.env = Object.assign(process.env, {
         GITHUB_ACTION: process.env.GITHUB_ACTION,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov-action",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov-action",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Upload coverage reports to Codecov from GitHub Actions",
   "main": "index.js",
   "scripts": {

--- a/src/buildExec.test.ts
+++ b/src/buildExec.test.ts
@@ -1,7 +1,7 @@
 import buildExec from './buildExec';
 const github = require('@actions/github');
 
-const VERSION = require('./version');
+import VERSION from './version';
 
 const context = github.context;
 

--- a/src/buildExec.ts
+++ b/src/buildExec.ts
@@ -1,7 +1,7 @@
 const core = require('@actions/core');
 const github = require('@actions/github');
 
-const VERSION = require('./version');
+import VERSION from './version';
 
 const context = github.context;
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
-const VERSION = 'v1.5.0';
+const VERSION = 'v1.5.2';
 
 export default VERSION;


### PR DESCRIPTION
Fixes an issue found https://github.com/codecov/codecov-action/issues/330 regarding version coming up as `github-actions-[Object object]`