### PR TITLE
refactor: remove unneeded codecov copy and unlink

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7539,7 +7539,7 @@ var buildExec = function () {
     var xcodeDerivedData = core.getInput('xcode_derived_data');
     var xcodePackage = core.getInput('xcode_package');
     var filepath = workingDir ?
-        workingDir + '/codecov.sh' : 'codecov.sh';
+        workingDir + '/codecov' : 'codecov';
     var execArgs = [filepath];
     execArgs.push('-n', "" + name, '-F', "" + flags, '-Q', "github-action-" + version);
     var options = {};
@@ -7658,57 +7658,23 @@ var buildExec = function () {
     if (xcodePackage) {
         execArgs.push('-J', "" + xcodePackage);
     }
-    return { execArgs: execArgs, options: options, filepath: filepath, failCi: failCi };
+    return { execArgs: execArgs, options: options, failCi: failCi };
 };
 /* harmony default export */ const src_buildExec = (buildExec);
 
 ;// CONCATENATED MODULE: ./src/index.ts
 var src_core = __nccwpck_require__(2186);
 var exec = __nccwpck_require__(1514);
-var fs = __nccwpck_require__(5747);
 
-var codecovScript = fs.readFileSync(__nccwpck_require__.ab + "codecov");
-var failCi;
-try {
-    var _a = src_buildExec(), execArgs_1 = _a.execArgs, options_1 = _a.options, filepath_1 = _a.filepath, failCi_1 = _a.failCi;
-    fs.writeFile(filepath_1, codecovScript, function (err) {
-        if (err && failCi_1) {
-            throw err;
-        }
-        else if (err) {
-            src_core.warning("Codecov warning: " + err.message);
-        }
-        exec.exec('bash', execArgs_1, options_1)["catch"](function (err) {
-            if (failCi_1) {
-                src_core.setFailed("Codecov failed with the following error: " + err.message);
-            }
-            else {
-                src_core.warning("Codecov warning: " + err.message);
-            }
-        })
-            .then(function () {
-            unlinkFile();
-        });
-        var unlinkFile = function () {
-            fs.unlink(filepath_1, function (err) {
-                if (err && failCi_1) {
-                    throw err;
-                }
-                else if (err) {
-                    src_core.warning("Codecov warning: " + err.message);
-                }
-            });
-        };
-    });
-}
-catch (error) {
+var _a = src_buildExec(), execArgs = _a.execArgs, options = _a.options, failCi = _a.failCi;
+exec.exec('bash', execArgs, options)["catch"](function (err) {
     if (failCi) {
-        src_core.setFailed("Codecov failed with the following error: " + error.message);
+        src_core.setFailed("Codecov failed with the following error: " + err.message);
     }
     else {
-        src_core.warning("Codecov warning: " + error.message);
+        src_core.warning("Codecov warning: " + err.message);
     }
-}
+});
 
 })();
 

--- a/src/buildExec.test.ts
+++ b/src/buildExec.test.ts
@@ -6,10 +6,10 @@ import VERSION from './version';
 const context = github.context;
 
 test('no arguments', () => {
-  const {execArgs, filepath, failCi} = buildExec();
+  const {execArgs, failCi} = buildExec();
 
   const args = [
-    'codecov.sh',
+    'codecov',
     '-n',
     '',
     '-F',
@@ -21,7 +21,6 @@ test('no arguments', () => {
     args.push('-C', `${context.payload.pull_request.head.sha}`);
   }
   expect(execArgs).toEqual(args);
-  expect(filepath).toEqual('codecov.sh');
   expect(failCi).toBeFalsy();
 });
 
@@ -65,9 +64,9 @@ test('all arguments', () => {
     process.env['INPUT_' + env.toUpperCase()] = envs[env];
   }
 
-  const {execArgs, filepath, failCi} = buildExec();
+  const {execArgs, failCi} = buildExec();
   expect(execArgs).toEqual([
-    'src/codecov.sh',
+    'src/codecov',
     '-n',
     'codecov',
     '-F',
@@ -142,7 +141,6 @@ test('all arguments', () => {
     '-J',
     'MyApp',
   ]);
-  expect(filepath).toEqual('src/codecov.sh');
   expect(failCi).toBeTruthy();
 
   for (const env of Object.keys(envs)) {

--- a/src/buildExec.ts
+++ b/src/buildExec.ts
@@ -50,7 +50,7 @@ const buildExec = () => {
   const xcodePackage = core.getInput('xcode_package');
 
   const filepath = workingDir ?
-    workingDir + '/codecov.sh' : 'codecov.sh';
+    workingDir + '/codecov' : 'codecov';
 
   const execArgs = [filepath];
   execArgs.push(
@@ -182,7 +182,7 @@ const buildExec = () => {
     execArgs.push('-J', `${xcodePackage}`);
   }
 
-  return {execArgs, options, filepath, failCi};
+  return {execArgs, options, failCi};
 };
 
 export default buildExec;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,51 +1,17 @@
 const core = require('@actions/core');
 const exec = require('@actions/exec');
 
-const fs = require('fs');
-
 import buildExec from './buildExec';
 
-const codecovScript = fs.readFileSync(__dirname + '/codecov');
+const {execArgs, options, failCi} = buildExec();
 
-let failCi;
-try {
-  const {execArgs, options, filepath, failCi} = buildExec();
-
-  fs.writeFile(filepath, codecovScript, (err) => {
-    if (err && failCi) {
-      throw err;
-    } else if (err) {
-      core.warning(`Codecov warning: ${err.message}`);
-    }
-
-    exec.exec('bash', execArgs, options)
-        .catch((err) => {
-          if (failCi) {
-            core.setFailed(
-                `Codecov failed with the following error: ${err.message}`,
-            );
-          } else {
-            core.warning(`Codecov warning: ${err.message}`);
-          }
-        })
-        .then(() => {
-          unlinkFile();
-        });
-
-    const unlinkFile = () => {
-      fs.unlink(filepath, (err) => {
-        if (err && failCi) {
-          throw err;
-        } else if (err) {
-          core.warning(`Codecov warning: ${err.message}`);
-        }
-      });
-    };
-  });
-} catch (error) {
-  if (failCi) {
-    core.setFailed(`Codecov failed with the following error: ${error.message}`);
-  } else {
-    core.warning(`Codecov warning: ${error.message}`);
-  }
-}
+exec.exec('bash', execArgs, options)
+    .catch((err) => {
+      if (failCi) {
+        core.setFailed(
+            `Codecov failed with the following error: ${err.message}`,
+        );
+      } else {
+        core.warning(`Codecov warning: ${err.message}`);
+      }
+    });


### PR DESCRIPTION
Since the uploader code is already stored in the action, it doesn't need to write and remove the file anymore.

Fixes https://github.com/codecov/codecov-action/issues/351
Fixes https://github.com/codecov/codecov-action/issues/346