### PR TITLE
refactor: Pull version from package.json

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7307,6 +7307,14 @@ module.exports = eval("require")("encoding");
 
 /***/ }),
 
+/***/ 306:
+/***/ ((module) => {
+
+"use strict";
+module.exports = JSON.parse('{"name":"codecov-action","version":"1.5.2","description":"Upload coverage reports to Codecov from GitHub Actions","main":"index.js","scripts":{"lint":"eslint src/*.*","test":"yarn run test-script && yarn run test-calculator && yarn run test-coverage","test-calculator":"jest --testPathPattern=demo/calculator/ --coverage --coverageDirectory=coverage/calculator","test-coverage":"jest --testPathPattern=demo/coverage-test/ --coverage --coverageDirectory=coverage/coverage-test","test-script":"jest --testPathPattern=src/ --coverage --coverageDirectory=coverage/script","build":"ncc build src/index.ts"},"repository":{"type":"git","url":"git+https://github.com/codecov/codecov-action.git"},"keywords":[],"author":"Ibrahim Ali","license":"MIT","bugs":{"url":"https://github.com/codecov/codecov-action/issues"},"homepage":"https://github.com/codecov/codecov-action#readme","dependencies":{"@actions/core":"^1.4.0","@actions/exec":"^1.1.0","@actions/github":"^5.0.0"},"devDependencies":{"@types/jest":"^26.0.23","@types/node":"^14.17.3","@typescript-eslint/eslint-plugin":"^4.26.1","@typescript-eslint/parser":"^4.26.1","@vercel/ncc":"^0.28.6","eslint":"^7.28.0","eslint-config-google":"^0.14.0","jest":"^26.6.3","jest-junit":"^12.2.0","ts-jest":"^26.5.6","typescript":"^4.3.2","yarn":"^1.22.10"}}');
+
+/***/ }),
+
 /***/ 2357:
 /***/ ((module) => {
 
@@ -7489,14 +7497,10 @@ var __webpack_exports__ = {};
 // ESM COMPAT FLAG
 __nccwpck_require__.r(__webpack_exports__);
 
-;// CONCATENATED MODULE: ./src/version.ts
-var VERSION = 'v1.5.2';
-/* harmony default export */ const version = (VERSION);
-
 ;// CONCATENATED MODULE: ./src/buildExec.ts
 var core = __nccwpck_require__(2186);
 var github = __nccwpck_require__(5438);
-
+var pjson = __nccwpck_require__(306);
 var context = github.context;
 var isTrue = function (variable) {
     var lowercase = variable.toLowerCase();
@@ -7541,7 +7545,7 @@ var buildExec = function () {
     var filepath = workingDir ?
         workingDir + '/codecov.sh' : 'codecov.sh';
     var execArgs = [filepath];
-    execArgs.push('-n', "" + name, '-F', "" + flags, '-Q', "github-action-" + version);
+    execArgs.push('-n', "" + name, '-F', "" + flags, '-Q', "github-action-" + pjson.version);
     var options = {};
     options.env = Object.assign(process.env, {
         GITHUB_ACTION: process.env.GITHUB_ACTION,

--- a/src/buildExec.test.ts
+++ b/src/buildExec.test.ts
@@ -1,7 +1,7 @@
 import buildExec from './buildExec';
 const github = require('@actions/github');
 
-import VERSION from './version';
+const pjson = require('../package.json');
 
 const context = github.context;
 
@@ -15,7 +15,7 @@ test('no arguments', () => {
     '-F',
     '',
     '-Q',
-    `github-action-${VERSION}`,
+    `github-action-${pjson.version}`,
   ];
   if (context.eventName == 'pull_request') {
     args.push('-C', `${context.payload.pull_request.head.sha}`);
@@ -73,7 +73,7 @@ test('all arguments', () => {
     '-F',
     'test',
     '-Q',
-    `github-action-${VERSION}`,
+    `github-action-${pjson.version}`,
     '-c',
     '-N',
     '83231650328f11695dfb754ca0f540516f188d27',

--- a/src/buildExec.ts
+++ b/src/buildExec.ts
@@ -1,7 +1,7 @@
 const core = require('@actions/core');
 const github = require('@actions/github');
 
-import VERSION from './version';
+const pjson = require('../package.json');
 
 const context = github.context;
 
@@ -59,7 +59,7 @@ const buildExec = () => {
       '-F',
       `${flags}`,
       '-Q',
-      `github-action-${VERSION}`,
+      `github-action-${pjson.version}`,
   );
 
   const options:any = {};

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,0 @@
-const VERSION = 'v1.5.2';
-
-export default VERSION;


### PR DESCRIPTION
Fixes https://github.com/codecov/codecov-action/issues/343

Removes the `version.js` file and pulls the version directly from `package.json`