### PR TITLE
fix: symlink codecov to an accessible location

### DIFF
--- a/codecov
+++ b/codecov
@@ -1,0 +1,1 @@
+dist/codecov


### PR DESCRIPTION
This should likely be a temporary solution until #366 is addressed.

Fixes #372