### PR TITLE
Update deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 >The latest release of this Action adds support for tokenless uploads from GitHub Actions!
 
 ## ⚠️  Deprecration of v1
-**On February 1, 2022, this version will be fully sunset and no longer function**
+**As of February 1, 2022, v1 has been fully sunset and no longer functions**
 
 Due to the [deprecation](https://about.codecov.io/blog/introducing-codecovs-new-uploader/) of the underlying bash uploader,
 the Codecov GitHub Action has released `v2` which will use the new [uploader](https://github.com/codecov/uploader). You can learn


### PR DESCRIPTION
The deprecation deadline has passed; this PR updates the language to be more accurate.

I also specified the version that was deprecated, since I actually had misunderstood the warning to be saying that "this version" was referring to the entire action itself, and that the guidance was to no longer use the action at all!  I think the new language will help prevent that kind of confusion for others.