### PR TITLE
Update README to contain correct information - inputs and negate feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Codecov's Action supports inputs from the user. These inputs, along with their d
 | Input  | Description | Usage |
 | :---:     |     :---:   |    :---:   |
 | `token`  | Used to authorize coverage report uploads  | *Required for private repos* |
-| `files`  | Comma-separated paths to the coverage report(s) | Optional
+| `files`  | Comma-separated paths to the coverage report(s). Negated paths are supported by starting with `!` | Optional
 | `directory` | Directory to search for coverage reports. | Optional
 | `dry_run` | Don't upload files to Codecov | Optional
 | `flags`  | Flag the upload to group coverage metrics (unittests, uitests, etc.). Multiple flags are separated by a comma (ui,chrome) | Optional
@@ -114,7 +114,7 @@ jobs:
         directory: ./coverage/reports/
         env_vars: OS,PYTHON
         fail_ci_if_error: true
-        files: ./coverage1.xml,./coverage2.xml
+        files: ./coverage1.xml,./coverage2.xml,!./cache
         flags: unittests
         name: codecov-umbrella
         path_to_write_report: ./coverage/codecov_report.txt

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ steps:
 
 ## Arguments
 
-Codecov's Action currently supports five inputs from the user: `token`, `file`, `flags`,`name`, and `fail_ci_if_error`. These inputs, along with their descriptions and usage contexts, are listed in the table below:
+Codecov's Action supports inputs from the user. These inputs, along with their descriptions and usage contexts, are listed in the table below:
 
 | Input  | Description | Usage |
 | :---:     |     :---:   |    :---:   |


### PR DESCRIPTION
I've found out after having issues with empty coverage reports that some files searching can be avoided by using negate path.

I've read the code here to understand it: https://github.com/codecov/uploader/blob/bc4b55a694478ac480a1fda4ed030c164c0c5438/src/index.ts#L220
Than I able to fix the action which tried uploading files like: `./yarn/cache/some-dep-coverage.zip`.