### PR TITLE
fix: update to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -120,5 +120,5 @@ branding:
   color: 'red'
   icon: 'umbrella'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -22072,7 +22072,7 @@ var core = __nccwpck_require__(2186);
 // EXTERNAL MODULE: ./node_modules/@actions/github/lib/github.js
 var github = __nccwpck_require__(5438);
 ;// CONCATENATED MODULE: ./package.json
-const package_namespaceObject = {"i8":"3.1.4"};
+const package_namespaceObject = {"i8":"3.1.5"};
 ;// CONCATENATED MODULE: ./src/buildExec.ts
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codecov-action",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "codecov-action",
-      "version": "3.1.4",
+      "version": "3.1.5",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov-action",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "Upload coverage reports to Codecov from GitHub Actions",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Merging this in from https://github.com/codecov/codecov-action/pull/1228

Node.js 16 actions are deprecated.

This should suppress the deprecation notice: Please update the following actions to use Node.js 20: codecov/codecov-action@v3

cc: @hallabro