### PR TITLE
chore(ci): bump to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,5 +69,5 @@ branding:
   color: 'red'
   icon: 'umbrella'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Mirroring https://github.com/codecov/codecov-action/pull/1228

Node.js 16 actions are deprecated.

This should suppress the deprecation notice:
> Please update the following actions to use Node.js 20: codecov/codecov-action@v3