### PR TITLE
Fix passing `token` example in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ steps:
     name: codecov-umbrella # optional
     fail_ci_if_error: true # optional (default = false)
     verbose: true # optional (default = false)
-  env:
     token: ${{ secrets.CODECOV_TOKEN }}
 ```
 >**Note**: This assumes that you've set your Codecov token inside *Settings > Secrets* as `CODECOV_TOKEN`. If not, you can [get an upload token](https://docs.codecov.io/docs/frequently-asked-questions#section-where-is-the-repository-upload-token-found-) for your specific repo on [codecov.io](https://www.codecov.io). Keep in mind that secrets are *not* available to forks of repositories.
@@ -126,7 +125,6 @@ jobs:
         flags: unittests
         name: codecov-umbrella
         verbose: true
-      env:
         token: ${{ secrets.CODECOV_TOKEN }}
 ```
 ## Contributing


### PR DESCRIPTION
The examples in the README are currently not working. One has to pass the token in the `with:` key, just like is done in the CI Actions in this repo.