### PR TITLE
Use updated syntax for GitHub Markdown notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ steps:
   env:
     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 ```
->**Note**: This assumes that you've set your Codecov token inside *Settings > Secrets* as `CODECOV_TOKEN`. If not, you can [get an upload token](https://docs.codecov.io/docs/frequently-asked-questions#section-where-is-the-repository-upload-token-found-) for your specific repo on [codecov.io](https://www.codecov.io). Keep in mind that secrets are *not* available to forks of repositories.
+> [!NOTE]
+> This assumes that you've set your Codecov token inside *Settings > Secrets* as `CODECOV_TOKEN`. If not, you can [get an upload token](https://docs.codecov.io/docs/frequently-asked-questions#section-where-is-the-repository-upload-token-found-) for your specific repo on [codecov.io](https://www.codecov.io). Keep in mind that secrets are *not* available to forks of repositories.
 
 ## Arguments
 


### PR DESCRIPTION
> [!NOTE]
> GitHub Markdown no longer support `>**Note**:` syntax

GitHub Discussions: https://github.com/orgs/community/discussions/16925