### PR TITLE
Removed mention of Mercurial

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Codecov's Action supports inputs from the user. These inputs, along with their d
 | `plugin` | plugins to run. Options: xcode, gcov, pycoverage. The default behavior runs them all. | Optional 
 | `plugins` | Comma-separated list of plugins for use during upload. | Optional 
 | `report_code` | The code of the report. If unsure, do not include | Optional 
-| `root_dir` | Used when not in git/hg project to identify project root directory | Optional 
+| `root_dir` | Used to specify the location of your   .git   root to identify project root directory | Optional 
 | `slug` | Specify the slug manually (Enterprise use) | Optional 
 | `url` | Specify the base url to upload (Enterprise use) | Optional 
 | `use_legacy_upload_endpoint` | Use the legacy upload endpoint | Optional 


### PR DESCRIPTION
To my knowledge , none of Codecov's supported code hosts support Mercurial, nor does the CLI itself.