### PR TITLE
fix: more verbose log message when failing to import pgp key

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -85,7 +85,7 @@ const verify = async (
         path.join(__dirname, `${uploaderName}.SHA256SUM`),
       ], async (err, verifyResult) => {
         if (err) {
-          setFailure('Codecov: Error importing pgp key', failCi);
+          setFailure(`Codecov: Error importing pgp key: ${err.message}`, failCi);
         }
         core.info(verifyResult);
         await validateSha();
@@ -101,7 +101,7 @@ const verify = async (
       path.join(__dirname, 'pgp_keys.asc'),
     ], async (err, importResult) => {
       if (err) {
-        setFailure('Codecov: Error importing pgp key', failCi);
+        setFailure(`Codecov: Error importing pgp key: ${err.message}`, failCi);
       }
       core.info(importResult);
       verifySignature();


### PR DESCRIPTION
I am running into the issue #1279, and the message below is not sufficient to diagnose the reason for the error.

```txt
==> macos OS detected
https://cli.codecov.io/latest/macos/codecov.SHA256SUM
==> Running version latest
Error: Codecov: Error importing pgp key
```
