### PR TITLE
style: Node Packages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import * as fs from 'fs';
-import * as https from 'https';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as https from 'node:https';
+import * as path from 'node:path';
 
 import * as exec from '@actions/exec';
 

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,7 +1,7 @@
-import * as crypto from 'crypto';
-import * as fs from 'fs';
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import * as gpg from 'gpg';
-import * as path from 'path';
 
 import * as core from '@actions/core';
 import {request} from 'undici';


### PR DESCRIPTION
Add the `node:` prefix to imports of node internal packages, making it easier to differentiate