### PR TITLE
Update README.md to point to docs about tokenless

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 `v4` of the Codecov GitHub Action will use the [Codecov CLI](https://github.com/codecov/codecov-cli) to upload coverage reports to Codecov.
 
 ### Breaking Changes
-- Tokenless uploading is unsupported. However, PRs made from forks to the upstream public repos will support tokenless (e.g. contributors to OS projects do not need the upstream repo's Codecov token)
+- Tokenless uploading is unsupported. However, PRs made from forks to the upstream public repos will support tokenless (e.g. contributors to OS projects do not need the upstream repo's Codecov token). For details, [see our docs](https://docs.codecov.com/docs/codecov-uploader#supporting-token-less-uploads-for-forks-of-open-source-repos-using-codecov)
 - Various arguments to the Action have been removed
 
 ### Dependabot


### PR DESCRIPTION
It wasn't very clear to the community that tokenless was supported. Linked to docs from the action readme.