### PR TITLE
docs: main branch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,10 +12,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '24 6 * * 5'
 

--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -2,7 +2,7 @@ name: Enforce License Compliance
 
 on:
   pull_request:
-    branches: [main, master]
+    branches: [main]
 
 jobs:
   enforce-license-compliance:

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -5,7 +5,7 @@ on:
   schedule:
     - cron: '43 20 * * 1'
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Inside your `.github/workflows/workflow.yml` file:
 
 ```yaml
 steps:
-- uses: actions/checkout@master
+- uses: actions/checkout@main
 - uses: codecov/codecov-action@v4
   with:
     fail_ci_if_error: true # optional (default = false)
@@ -50,7 +50,7 @@ The Codecov token can also be passed in via environment variables:
 
 ```yaml
 steps:
-- uses: actions/checkout@master
+- uses: actions/checkout@main
 - uses: codecov/codecov-action@v4
   with:
     fail_ci_if_error: true # optional (default = false)
@@ -130,9 +130,9 @@ jobs:
       OS: ${{ matrix.os }}
       PYTHON: '3.10'
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - name: Setup Python
-      uses: actions/setup-python@master
+      uses: actions/setup-python@main
       with:
         python-version: 3.10
     - name: Generate coverage report


### PR DESCRIPTION
Rename `master` to `main`.
Note: As the `master` branch is no longer available, both workflows haven't run in the last few months