### PR TITLE
Use an existing token even if the PR is from a fork

### DIFF
--- a/src/buildExec.ts
+++ b/src/buildExec.ts
@@ -46,11 +46,11 @@ const isPullRequestFromFork = (): boolean => {
 };
 
 const getToken = async (): Promise<string> => {
-  if (isPullRequestFromFork()) {
+  let token = core.getInput('token');
+  if (!token && isPullRequestFromFork()) {
     core.info('==> Fork detected, tokenless uploading used');
     return Promise.resolve('');
   }
-  let token = core.getInput('token');
   let url = core.getInput('url');
   const useOIDC = isTrue(core.getInput('use_oidc'));
   if (useOIDC) {


### PR DESCRIPTION
This fixes https://github.com/codecov/feedback/issues/358 and #1457 and would greatly improve the situation for everyone using Codecov until https://github.com/codecov/engineering-team/issues/1574 has been solved and released.

### What‘s the problem?

Even if the fork provides a Codecov token, it is ignored and tokenless uploading is used.

### How das this PR fix it?

It adjusts the logic so that an existing token is always used, regardless of whether the PR originates from a fork or not.
