### PR TITLE
Add globbing support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+dist/ linguist-generated

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,7 @@ inputs:
   file:
     description: 'Path to coverage file to upload'
     required: false
+    deprecationMessage: 'Use the `files` input instead, it supports globs'
   files:
     description: 'Comma-separated list of files to upload'
     required: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@actions/core": "^1.11.1",
         "@actions/exec": "^1.1.1",
         "@actions/github": "^6.0.0",
+        "tinyglobby": "^0.2.9",
         "undici": "5.28.4"
       },
       "devDependencies": {
@@ -5183,6 +5184,45 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.9.tgz",
+      "integrity": "sha512-8or1+BGEdk1Zkkw2ii16qSS7uVrQJPre5A9o/XkWPATkk23FZh/15BKFxPnlTy6vkljZxLqYCzzBMj30ZrSvjw==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.0",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
+      "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@actions/core": "^1.11.1",
     "@actions/exec": "^1.1.1",
     "@actions/github": "^6.0.0",
+    "tinyglobby": "^0.2.9",
     "undici": "5.28.4"
   },
   "devDependencies": {

--- a/src/buildExec.ts
+++ b/src/buildExec.ts
@@ -3,6 +3,7 @@
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 import {type PullRequestEvent} from '@octokit/webhooks-types';
+import {glob} from 'tinyglobby';
 
 import {setFailure} from './helpers';
 
@@ -309,15 +310,15 @@ const buildUploadExec = async (): Promise<{
     uploadExecArgs.push('-f', file);
   }
   if (files) {
-    files
+    const globs = files
         .split(',')
         .map((f) => f.trim())
-        .forEach((f) => {
-          if (f.length > 0) {
-          // this handles trailing commas
-            uploadExecArgs.push('-f', f);
-          }
-        });
+        // This handles trailing commas.
+        .filter((f) => f.length > 0);
+    const globbed = await glob(globs);
+    globbed.map((f) => {
+      uploadExecArgs.push('-f', f);
+    });
   }
   if (flags) {
     flags


### PR DESCRIPTION
Fixes #770 for real (and fixes #1582).

Personally, I think this change belongs in the cli, but I decided that rewriting the argument parsing there was a much larger endeavor than this.
Tests are failing because it now globs the files, but they don't actually exist. I suppose we need fixtures then? Shouldn't be breaking in practice though.