### PR TITLE
fix: typo in `inputs.disable_safe_directory`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -155,7 +155,7 @@ runs:
   using: "composite"
   steps:
     - name: Set safe directory
-      if: ${{ inputs.set_safe_directory != 'true' }}
+      if: ${{ inputs.disable_safe_directory != 'true' }}
       shell: bash
       run: |
         git config --global --add safe.directory ${{ github.workspace }}


### PR DESCRIPTION
https://github.com/codecov/codecov-action/commit/bb7467c2bce05781760a0964d48e35e96ee59505 broke the `disable_safe_directory` input.

While the [input definition](https://github.com/codecov/codecov-action/commit/bb7467c2bce05781760a0964d48e35e96ee59505#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R24-R27) was kept the same, the usage in code was changed from [`disable_safe_directory`](https://github.com/codecov/codecov-action/commit/bb7467c2bce05781760a0964d48e35e96ee59505#diff-340f73bcb6cfc5bb360e31166bd24f415f42d51df477aecb2824c4a34c391f0bL233) to [`set_safe_directory`](https://github.com/codecov/codecov-action/commit/bb7467c2bce05781760a0964d48e35e96ee59505#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R159).

I assume this to be a typo, since the input logic still disables when the input is set to true.

It would be great to have this resolved swiftly, @thomasrockhu-codecov. :)