### PR TITLE
Add use_python option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,3 +290,7 @@ for the full list.
 - #166 Bump requestretry from 4.1.1 to 4.1.2
 - #169 Bump typescript from 4.0.5 to 4.1.2
 - #178 Bump @types/jest from 26.0.15 to 26.0.19
+
+## 5.0.3
+### Features
+- Added an option to use Python to run `codecov-cli` in `action.yml` by introducing a new input `use_python`.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ steps:
     name: codecov-umbrella # optional
     token: ${{ secrets.CODECOV_TOKEN }} # required
     verbose: true # optional (default = false)
+    use_python: true # optional (default = false)
 ```
 
 The Codecov token can also be passed in via environment variables:
@@ -82,6 +83,7 @@ steps:
     flags: unittests # optional
     name: codecov-umbrella # optional
     verbose: true # optional (default = false)
+    use_python: true # optional (default = false)
   env:
     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 ```
@@ -138,6 +140,7 @@ Codecov's Action supports inputs from the user. These inputs, along with their d
 | `verbose` | Specify whether the Codecov output should be verbose | Optional
 | `version` | Specify which version of the Codecov CLI should be used. Defaults to `latest` | Optional
 | `working-directory` | Directory in which to execute codecov.sh | Optional
+| `use_python` | Use Python to run codecov-cli instead of binary | Optional
 
 ### Example `workflow.yml` with Codecov Action
 
@@ -175,6 +178,7 @@ jobs:
         name: codecov-umbrella
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true
+        use_python: true
 ```
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -146,6 +146,10 @@ inputs:
   working-directory:
     description: 'Directory in which to execute codecov.sh'
     required: false
+  use_python:
+    description: 'Use Python to run codecov-cli instead of binary'
+    required: false
+    default: 'false'
 
 branding:
   color: 'red'
@@ -214,6 +218,12 @@ runs:
         GITHUB_EVENT_NAME: ${{ github.event_name }}
         GITHUB_EVENT_NUMBER: ${{ github.event.number }}
         GITHUB_EVENT_PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
+    - name: Install codecov-cli using Python
+      if: ${{ inputs.use_python == 'true' }}
+      shell: bash
+      run: |
+        pip install codecov-cli
 
     - name: Upload coverage to Codecov
       run: ${GITHUB_ACTION_PATH}/dist/codecov.sh

--- a/action.yml
+++ b/action.yml
@@ -266,3 +266,4 @@ runs:
         CC_VERBOSE: ${{ inputs.verbose }}
         CC_VERSION: ${{ inputs.version }}
         CC_YML_PATH: ${{ inputs.codecov_yml_path }}
+        CC_USE_PYTHON: ${{ inputs.use_python }}


### PR DESCRIPTION
Allows the user to specify that codecov-cli be run with python to allow it to run without precompiled binaries.
Specifically, I have deployed a self-hosted runner for the s390x architecture, and I want that program to continue to run properly.