### PR TITLE
Remove mistake from options table

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ d as described here: https://docs.codecov.com/docs/codecov-yaml#can-i-name-the-f
 | `exclude` | Comma-separated list of folders to exclude from search. | Optional
 | `fail_ci_if_error` | On error, exit with non-zero code | Optional
 | `files` | Comma-separated explicit list of files to upload. These will be added to the coverage files found for upload. If you wish to only upload the specified files, please consider using "disable-search" to disable uploading other files. | Optional
-tional
 | `flags` | Comma-separated list of flags to upload to group coverage metrics. | Optional
 | `git_service` | Override the git_service (e.g. github_enterprise) | Optional
 | `gcov_args` | Extra arguments to pass to gcov | Optional


### PR DESCRIPTION
The table included an erroneous `tional` in its own row that seems to be a left-over mistake from changes to its context.