### PR TITLE
Put quotes around `${{ inputs.token }}` in `action.yml`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -177,9 +177,9 @@ runs:
         then
             echo "CC_TOKEN=${{ env.CODECOV_TOKEN }}" >> "$GITHUB_ENV"
         else
-          if [ -n ${{ inputs.token }} ];
+          if [ -n "${{ inputs.token }}" ];
           then
-            CC_TOKEN=$(echo ${{ inputs.token }} | tr -d '\n')
+            CC_TOKEN=$(echo "${{ inputs.token }}" | tr -d '\n')
             echo "CC_TOKEN=$CC_TOKEN" >> "$GITHUB_ENV"
           fi
         fi


### PR DESCRIPTION
While debugging a "Token required because branch is protected" problem with two of my repositories, I noticed this in the codecov-action logs:

```
    if [ "false" == 'true' ];
    then
      # {"count":1984,"value":"***"}
      CC_TOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://codecov.io" | cut -d\" -f6)
      echo "CC_TOKEN=$CC_TOKEN" >> "$GITHUB_ENV"
    elif [ -n "" ];
    then
        echo "CC_TOKEN=" >> "$GITHUB_ENV"
    else
      if [ -n ***

     ];
      then
        CC_TOKEN=$(echo ***

     | tr -d '\n')
        echo "CC_TOKEN=$CC_TOKEN" >> "$GITHUB_ENV"
      fi
    fi
    shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
    env:
      CARGO_HOME: /home/runner/.cargo
      CARGO_INCREMENTAL: 0
      CARGO_TERM_COLOR: always
      CACHE_ON_FAILURE: false
    ##[endgroup]
    /home/runner/work/_temp/0f1d96ca-0f3a-423c-b405-fa68034346d8.sh: line 10: [: missing `]'
    /home/runner/work/_temp/0f1d96ca-0f3a-423c-b405-fa68034346d8.sh: line 12: ]: command not found
```

Note the newline in the middle of `if [ -n *** ]` and the error messages at the bottom.  Earlier in my debugging, I had determined that the `CODECOV_TOKEN` secret (which I don't have permission to change) contained two trailing newlines, and it seems `action.yml` doesn't handle those right due to a lack of quotes around `${{inputs.token}}`.  This PR fixes this.

Fixes #1694.