### PR TITLE
 Fix a typo in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@main
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Generate coverage report
       run: |
         pip install pytest


### PR DESCRIPTION
The current version of the script treats the Python version as a number, leading to the following error:

```
Run actions/setup-python@main
Installed versions
  Version 3.1 was not found in the local cache
  Error: The version '3.1' with architecture 'x64' was not found for Ubuntu 24.04.
```

To fix this, add quotes to treat the version as a string.