### PR TITLE
Fix use of safe.directory inside containers

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -182,7 +182,7 @@ runs:
       shell: bash
       run: |
         git config --global --add safe.directory "${{ github.workspace }}"
-        git config --global --add safe.directory "${{ GITHUB_WORKSPACE }}"
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
     - name: Set fork
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -181,7 +181,7 @@ runs:
       if: ${{ inputs.disable_safe_directory != 'true' }}
       shell: bash
       run: |
-        git config --global --add safe.directory ${{ github.workspace }}
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
     - name: Set fork
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -181,6 +181,7 @@ runs:
       if: ${{ inputs.disable_safe_directory != 'true' }}
       shell: bash
       run: |
+        git config --global --add safe.directory "${{ github.workspace }}"
         git config --global --add safe.directory "${{ GITHUB_WORKSPACE }}"
 
     - name: Set fork

--- a/action.yml
+++ b/action.yml
@@ -181,7 +181,7 @@ runs:
       if: ${{ inputs.disable_safe_directory != 'true' }}
       shell: bash
       run: |
-        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        git config --global --add safe.directory "${{ GITHUB_WORKSPACE }}"
 
     - name: Set fork
       shell: bash


### PR DESCRIPTION
Inside a container the actual workspace path is a mount point and not the same as outside the container. E.g.:
- `${{github.workspace}} == /home/runner/work/locale/locale`
- `$GITHUB_WORKSPACE == /__w/locale/locale`

So it seems `/home/runner/work` is mounted at `/__w` and this is reflected by the environment variable but not the context.    So use that variable instead.

Fixes #1767