### PR TITLE
Fix description for report_type input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -116,7 +116,7 @@ inputs:
     description: 'The code of the report if using local upload. If unsure, leave default. Read more here https://docs.codecov.com/docs/the-codecov-cli#how-to-use-local-upload'
     required: false
   report_type:
-    description: 'The type of file to upload, coverage by default. Possible values are "testing", "coverage".'
+    description: 'The type of file to upload, coverage by default. Possible values are "test_results", "coverage".'
     required: false
   root_dir:
     description: 'Root folder from which to consider paths on the network section. Defaults to current working directory.'


### PR DESCRIPTION
The description stated "testing" was a valid value, but that leads to an error if you try to use it. The error message indicates that the value should be "test_results" instead.