### PR TITLE
update wrapper submodule to 0.2.0, add recurse_submodules arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Codecov's Action supports inputs from the user. These inputs, along with their d
 | `override_commit` | Commit SHA (with 40 chars) | Optional
 | `override_pr` | Specify the pull request number manually. Used to override pre-existing CI environment variables. | Optional
 | `plugins` | Comma-separated list of plugins to run. Specify `noop` to turn off all plugins | Optional
+| `recurse_submodules` | Whether to enumerate files inside of submodules for path-fixing purposes. Off by default. | Optional
 | `report_code` | The code of the report if using local upload. If unsure, leave unset. Read more here https://docs.codecov.com/docs/the-codecov-cli#how-to-use-local-upload | Optional
 | `report_type` | The type of file to upload, coverage by default. Possible values are "test_results", "coverage". | Optional
 | `root_dir` | Root folder from which to consider paths on the network section. Defaults to current working directory. | Optional

--- a/action.yml
+++ b/action.yml
@@ -112,6 +112,9 @@ inputs:
   plugins:
     description: 'Comma-separated list of plugins to run. Specify `noop` to turn off all plugins'
     required: false
+  recurse_submodules:
+    description: 'Whether to enumerate files inside of submodules for path-fixing purposes. Off by default.'
+    default: 'false'
   report_code:
     description: 'The code of the report if using local upload. If unsure, leave default. Read more here https://docs.codecov.com/docs/the-codecov-cli#how-to-use-local-upload'
     required: false
@@ -300,6 +303,7 @@ runs:
         CC_OS: ${{ inputs.os }}
         CC_PARENT_SHA: ${{ inputs.commit_parent }}
         CC_PLUGINS: ${{ inputs.plugins }}
+        CC_RECURSE_SUBMODULES: ${{ inputs.recurse_submodules }}
         CC_REPORT_TYPE: ${{ inputs.report_type }}
         CC_RUN_CMD: ${{ inputs.run_command }}
         CC_SERVICE: ${{ inputs.git_service }}


### PR DESCRIPTION
- https://github.com/codecov/codecov-cli/pull/650 added this arg to the CLI
- https://github.com/codecov/wrapper/pull/48 added it to the bash wrapper

this PR updates the wrapper and adds the arg to the GHA