### PR TITLE
docs: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 
 The `v5` release also coincides with the opt-out feature for tokens for public repositories. In the `Global Upload Token` section of the settings page of an organization in codecov.io, you can set the ability for Codecov to receive a coverage reports from any source. This will allow contributors or other members of a repository to upload without needing access to the Codecov token. For more details see [how to upload without a token](https://docs.codecov.com/docs/codecov-tokens#uploading-without-a-token).
 
-> [!WARNING] > **The following arguments have been changed**
->
+> [!WARNING]
+> **The following arguments have been changed**
 > - `file` (this has been deprecated in favor of `files`)
 > - `plugin` (this has been deprecated in favor of `plugins`)
 


### PR DESCRIPTION
Fixed markdown formatting issue in the README.md file where an extra `>` character was causing incorrect rendering of the warning block.

| Before | After |
|----|----|
| <p align="center"><img width="481" alt="image" src="https://github.com/user-attachments/assets/cb96d88b-7444-4d5e-9c66-3e8efb44e23a"></p> |<p align="center"><img width="474" alt="image" src="https://github.com/user-attachments/assets/2e0dd3b9-d93c-42c8-a0af-043b474bf9e4"></p> |
