### PR TITLE
feat: add http_headers input for custom header injection

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,9 @@ inputs:
     description: 'If no coverage reports are found, do not raise an exception.'
     required: false
     default: 'false'
+  http_headers:
+    description: 'Extra HTTP headers to send with every request, one per line (format: Header-Name:Value).'
+    required: false
   job_code:
     description: ''
     required: false
@@ -331,6 +334,7 @@ runs:
         CC_GCOV_INCLUDE: ${{ inputs.gcov_include }}
         CC_GIT_SERVICE: ${{ inputs.git_service }}
         CC_HANDLE_NO_REPORTS_FOUND: ${{ inputs.handle_no_reports_found }}
+        CC_HTTP_HEADERS: ${{ inputs.http_headers }}
         CC_JOB_CODE: ${{ inputs.job_code }}
         CC_LEGACY: ${{ inputs.use_legacy_upload_endpoint }}
         CC_NAME: ${{ inputs.name }}

--- a/dist/codecov.sh
+++ b/dist/codecov.sh
@@ -155,6 +155,12 @@ then
 fi
 CC_CLI_ARGS+=( $(write_bool_args CC_DISABLE_TELEM) )
 CC_CLI_ARGS+=( $(write_bool_args CC_VERBOSE) )
+if [ -n "$CC_HTTP_HEADERS" ]; then
+  while IFS= read -r header; do
+    [ -z "$header" ] && continue
+    CC_CLI_ARGS+=( "--http-header" "$header" )
+  done <<< "$CC_HTTP_HEADERS"
+fi
 CC_ARGS=()
 if [ "$CC_RUN_CMD" == "upload-coverage" ]; then
 # Args for create commit


### PR DESCRIPTION
## Summary
- Add `http_headers` input to the GitHub Action for passing custom HTTP headers (e.g. Cloudflare Access) to the CLI
- Map the input to `CC_HTTP_HEADERS` env var and split comma-separated values into `--http-header` CLI flags

## Related
- CLI PR: https://github.com/getsentry/prevent-cli/pull/122