### PR TITLE
fix: resolve CLI version before download to prevent sha256sum race condition

### DIFF
--- a/dist/codecov.sh
+++ b/dist/codecov.sh
@@ -91,14 +91,15 @@ else
   [[ $CC_OS == "macos" ]]  && \
     ! command -v gpg 2>&1 >/dev/null && \
     HOMEBREW_NO_AUTO_UPDATE=1 brew install gpg
+  v_url="https://cli.codecov.io/api/${CC_OS}/${CC_VERSION}"
+  v=$(curl $retry --retry-all-errors -s "$v_url" -H "Accept:application/json" | tr \{ '\n' | tr , '\n' | tr \} '\n' | grep "\"version\"" | awk  -F'"' '{print $4}' | tail -1)
+  CC_RESOLVED_VERSION="${v:-$CC_VERSION}"
   CC_URL="${CC_CLI_URL:-https://cli.codecov.io}"
-  CC_URL="$CC_URL/${CC_VERSION}"
+  CC_URL="$CC_URL/${CC_RESOLVED_VERSION}"
   CC_URL="$CC_URL/${CC_OS}/${CC_FILENAME}"
   say "$g ->$x Downloading $b${CC_URL}$x"
   curl -O $retry "$CC_URL"
-  say "$g==>$x Finishing downloading $b${CC_OS}:${CC_VERSION}$x"
-  v_url="https://cli.codecov.io/api/${CC_OS}/${CC_VERSION}"
-  v=$(curl $retry --retry-all-errors -s "$v_url" -H "Accept:application/json" | tr \{ '\n' | tr , '\n' | tr \} '\n' | grep "\"version\"" | awk  -F'"' '{print $4}' | tail -1)
+  say "$g==>$x Finishing downloading $b${CC_OS}:${CC_RESOLVED_VERSION}$x"
   say "      Version: $b$v$x"
   say " "
 fi
@@ -115,7 +116,7 @@ else
   # One-time step
   say "$g==>$x Verifying GPG signature integrity"
   sha_url="https://cli.codecov.io"
-  sha_url="${sha_url}/${CC_VERSION}/${CC_OS}"
+  sha_url="${sha_url}/${CC_RESOLVED_VERSION:-$CC_VERSION}/${CC_OS}"
   sha_url="${sha_url}/${CC_FILENAME}.SHA256SUM"
   say "$g ->$x Downloading $b${sha_url}$x"
   say "$g ->$x Downloading $b${sha_url}.sig$x"


### PR DESCRIPTION
## What

Resolve the exact CLI version (via the version API) before downloading the binary, and use that pinned version for both the binary URL and the SHA256SUM URL.

## Why

When `CC_VERSION` is `latest`, the script makes two separate HTTP requests for the binary and the SHA256SUM — both using the `latest` redirect. If a new CLI release deploys between those two requests, the binary comes from version N while the checksum comes from version N+1, causing sha256sum verification to fail.

This is what happened on April 21 2026 and affected runners across multiple projects (see the reports in #1940).

Fixes #1940

## How

Move the version API query before the binary download. Store the resolved version in `CC_RESOLVED_VERSION` (fallback to `CC_VERSION` if the API call fails), then use `CC_RESOLVED_VERSION` for both the binary URL and the SHA256SUM URL. This pins both requests to the same specific release, closing the race window.

I considered adding retry-with-re-download logic as an alternative, but that would mask the root cause. Pre-resolving the version is one extra API call and eliminates the window entirely.

Note: the same change should eventually be applied to `codecov/wrapper` (`scripts/download.sh` and `scripts/validate.sh`), but this patch to `dist/codecov.sh` addresses the immediate breakage.

## Scope

- Included: `dist/codecov.sh` — resolve version before download, use resolved version for both binary and checksum URLs
- NOT included: equivalent changes to `codecov/wrapper` source scripts (separate repo/PR)

## Verification

- `bash -n dist/codecov.sh` passes (syntax check)
- At runtime with `CC_VERSION=latest`, the download log will show a specific version URL (e.g. `/v11.2.8/windows/codecov.exe`) instead of `/latest/windows/codecov.exe`, confirming the version was pinned before the download
- For explicitly pinned `CC_VERSION` values, behavior is unchanged

## AI Disclosure

AI tools assisted with implementation. Every change was manually reviewed, tested with `bash -n`, and verified against the script's existing conventions.