### PR TITLE
fix: prevent template injection in run: steps (VULN-1652)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -177,6 +177,8 @@ runs:
   steps:
     - name: Check system dependencies
       shell: sh
+      env:
+        INPUT_SKIP_VALIDATION: ${{ inputs.skip_validation }}
       run: |
         missing_deps=""
 
@@ -188,7 +190,7 @@ runs:
         done
 
         # Check for gpg only if validation is not being skipped
-        if [ "${{ inputs.skip_validation }}" != "true" ]; then
+        if [ "$INPUT_SKIP_VALIDATION" != "true" ]; then
           if ! command -v gpg >/dev/null 2>&1; then
             missing_deps="$missing_deps gpg"
           fi
@@ -245,24 +247,27 @@ runs:
     - name: Get and set token
       shell: bash
       run: |
-        if [ "${{ inputs.use_oidc }}" == 'true' ] && [ "$CC_FORK" != 'true' ];
+        if [ "$INPUT_USE_OIDC" == 'true' ] && [ "$CC_FORK" != 'true' ];
         then
           echo "CC_TOKEN=$CC_OIDC_TOKEN" >> "$GITHUB_ENV"
-        elif [ -n "${{ env.CODECOV_TOKEN }}" ];
+        elif [ -n "$INPUT_CODECOV_TOKEN" ];
         then
           echo -e "\033[0;32m==>\033[0m Token set from env"
-            echo "CC_TOKEN=${{ env.CODECOV_TOKEN }}" >> "$GITHUB_ENV"
+            echo "CC_TOKEN=$INPUT_CODECOV_TOKEN" >> "$GITHUB_ENV"
         else
-          if [ -n "${{ inputs.token }}" ];
+          if [ -n "$INPUT_TOKEN" ];
           then
             echo -e "\033[0;32m==>\033[0m Token set from input"
-            CC_TOKEN=$(echo "${{ inputs.token }}" | tr -d '\n')
+            CC_TOKEN=$(echo "$INPUT_TOKEN" | tr -d '\n')
             echo "CC_TOKEN=$CC_TOKEN" >> "$GITHUB_ENV"
           fi
         fi
       env:
         CC_OIDC_TOKEN: ${{ steps.oidc.outputs.result }}
         CC_OIDC_AUDIENCE: ${{ inputs.url || 'https://codecov.io' }}
+        INPUT_USE_OIDC: ${{ inputs.use_oidc }}
+        INPUT_TOKEN: ${{ inputs.token }}
+        INPUT_CODECOV_TOKEN: ${{ env.CODECOV_TOKEN }}
 
     - name: Override branch for forks
       shell: bash


### PR DESCRIPTION
## Summary

Fixes the template injection vulnerability.

Three `run:` steps in `action.yml` were directly interpolating `${{ inputs.xxx }}` template expressions inside shell scripts. Because GitHub Actions resolves these expressions **before** the shell sees the script, a consumer workflow that passes user-controlled data into `skip_validation`, `use_oidc`, or `token` could achieve arbitrary command execution on the runner.

### Changes

| Step | Vulnerable expression | Fix |
|---|---|---|
| Check system dependencies | `"${{ inputs.skip_validation }}"` in `if` condition | Moved to `env: INPUT_SKIP_VALIDATION`, referenced as `$INPUT_SKIP_VALIDATION` |
| Get and set token | `"${{ inputs.use_oidc }}"` in `if` condition | Moved to `env: INPUT_USE_OIDC`, referenced as `$INPUT_USE_OIDC` |
| Get and set token | `"${{ inputs.token }}"` in `if` condition and command substitution | Moved to `env: INPUT_TOKEN`, referenced as `$INPUT_TOKEN` |
| Get and set token | `"${{ env.CODECOV_TOKEN }}"` in `elif` condition and echo | Moved to `env: INPUT_CODECOV_TOKEN`, referenced as `$INPUT_CODECOV_TOKEN` |

The env-var indirection pattern is already used consistently in other steps in this file (e.g., the "Set fork" and "Override branch for forks" steps). This change makes the three affected steps consistent with that existing safe pattern.